### PR TITLE
Check if Intl is available before using it

### DIFF
--- a/lib/starts-with.js
+++ b/lib/starts-with.js
@@ -1,5 +1,8 @@
-var collator = new Intl.Collator('default', { sensitivity: 'base', usage: 'search' })
+var collator = typeof Intl === 'object' ? 
+  new Intl.Collator('default', { sensitivity: 'base', usage: 'search' }) : 
+  null
 
 module.exports = function startsWith (text, target) {
-  return collator.compare(text.slice(0, target.length), target) === 0
+  if (collator) return collator.compare(text.slice(0, target.length), target) === 0
+  else return text.slice(0, target.length).localeCompare(target) === 0
 }


### PR DESCRIPTION
I'm adding mentions autocomplete to Manyverse and started using this module in the Node.js side. It crashes the app on startup because `Intl` is not available on Node.js Mobile. This PR checks if that exists before using it, falls back to `string.localeCompare`.