### PR TITLE
add string.prototype.startsWith fallback

### DIFF
--- a/lib/starts-with.js
+++ b/lib/starts-with.js
@@ -1,8 +1,9 @@
-var collator = typeof Intl === 'object' ? 
-  new Intl.Collator('default', { sensitivity: 'base', usage: 'search' }) : 
+var collator = typeof Intl === 'object' ?
+  new Intl.Collator('default', { sensitivity: 'base', usage: 'search' }) :
   null
 
 module.exports = function startsWith (text, target) {
   if (collator) return collator.compare(text.slice(0, target.length), target) === 0
-  else return text.slice(0, target.length).localeCompare(target) === 0
+  else if (text.slice(0, target.length).localeCompare(target) === 0) return true
+  else return text.startsWith(target)
 }


### PR DESCRIPTION
So it turns out for some reason on some mobile devices we get `"em".localeCompare("em") === 1`, so this PR adds a fallback to use `"emile".startsWith("em")` in case that previous one fails. I tested this code running in Manyverse.