### PR TITLE
use lowercase to match strings

### DIFF
--- a/lib/starts-with.js
+++ b/lib/starts-with.js
@@ -2,7 +2,9 @@ var collator = typeof Intl === 'object' ?
   new Intl.Collator('default', { sensitivity: 'base', usage: 'search' }) :
   null
 
-module.exports = function startsWith (text, target) {
+module.exports = function startsWith (rawText, rawTarget) {
+  const text = rawText.toLocaleLowerCase()
+  const target = rawTarget.toLocaleLowerCase()
   if (collator) return collator.compare(text.slice(0, target.length), target) === 0
   else if (text.slice(0, target.length).localeCompare(target) === 0) return true
   else return text.startsWith(target)


### PR DESCRIPTION
If you ask for "Mix", ssb-suggest won't give you "mixmix". If you ask for "powersour", ssb-suggest won't give you "Powersource". I think it makes sense for this module to interpret user input with a lens of "fuzziness" or approximation, it's better to err with *more* suggestions than to err on less suggestions.

In a future PR, we could even use something like https://www.npmjs.com/package/leven so that if the user inputs "mixmx" it would suggest to me "mixmix"