### PR TITLE
better about mentions

### DIFF
--- a/lib/normalise.js
+++ b/lib/normalise.js
@@ -1,0 +1,3 @@
+module.exports = function normalise (word) {
+  return word.toLocaleLowerCase().replace(/(\s|-|_)/g, '')
+}

--- a/lib/reduce-matches.js
+++ b/lib/reduce-matches.js
@@ -2,40 +2,29 @@ const normalise = require('./normalise')
 const startsWith = require('./starts-with')
 
 module.exports = function reduceMatches (text, matches) {
-  var seenIds = new Set()
-
   const exactMatches = matches
     .filter(m => m.name === text)
     .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
-  exactMatches.forEach(m => seenIds.add(m.avatar.id))
 
   const normText = normalise(text)
 
   const partialPreferredNameMatch = matches
-    .filter(m => !seenIds.has(m.avatar.id))
     .filter(isPreferredName)
     .filter(m => startsWith(normalise(m.name), normText, false))
-  partialPreferredNameMatch.forEach(m => seenIds.add(m.avatar.id))
 
   const exactNormalisedMatches = matches
-    .filter(m => !seenIds.has(m.avatar.id))
     .filter(m => normalise(m.name) === normText)
     .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
-  exactNormalisedMatches.forEach(m => seenIds.add(m.avatar.id))
 
   const partialExactMatches = matches
-    .filter(m => !seenIds.has(m.avatar.id))
     .filter(m => startsWith(m.name, text, false))
     .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
-  partialExactMatches.forEach(m => seenIds.add(m.avatar.id))
 
   const partialNormalisedMatches = matches
-    .filter(m => !seenIds.has(m.avatar.id))
     .filter(m => startsWith(normalise(m.name), normText, false))
     .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
-  partialNormalisedMatches.forEach(m => seenIds.add(m.avatar.id))
 
-  const dreggs = matches.filter(m => !seenIds.has(m.avatar.id))
+  const dreggs = matches
 
   const prioritisedMatches = [
     ...exactMatches,
@@ -46,7 +35,7 @@ module.exports = function reduceMatches (text, matches) {
     ...dreggs
   ]
 
-  seenIds = new Set() // reset for another use!
+  var seenIds = new Set()
 
   return prioritisedMatches
 

--- a/lib/reduce-matches.js
+++ b/lib/reduce-matches.js
@@ -1,56 +1,54 @@
 const normalise = require('./normalise')
 const startsWith = require('./starts-with')
 
-module.exports = function sort (text, matches) {
-  const normText = normalise(text)
+module.exports = function reduceMatches (text, matches) {
   var seenIds = new Set()
 
-  return matches
-    // for each person, bubble up the option where the match.name is the best match to search
-    .sort((a, b) => {
-      // if text+name are exact match
-      if (a.name === text) return -1
-      if (b.name === text) return +1
+  const exactMatches = matches
+    .filter(m => m.name === text)
+    .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
+  exactMatches.forEach(m => seenIds.add(m.avatar.id))
 
-      const normA = normalise(a.name)
-      const normB = normalise(b.name)
+  const normText = normalise(text)
 
-      // where normalised text+name are exact match
-      if (normA === normText) return -1
-      if (normB === normText) return +1
+  const partialPreferredNameMatch = matches
+    .filter(m => !seenIds.has(m.avatar.id))
+    .filter(isPreferredName)
+    .filter(m => startsWith(normalise(m.name), normText, false))
+  partialPreferredNameMatch.forEach(m => seenIds.add(m.avatar.id))
 
-      // where name is matching exactly so far
-      if (startsWith(a.name, text, false)) return -1
-      if (startsWith(b.name, text, false)) return +1
+  const exactNormalisedMatches = matches
+    .filter(m => !seenIds.has(m.avatar.id))
+    .filter(m => normalise(m.name) === normText)
+    .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
+  exactNormalisedMatches.forEach(m => seenIds.add(m.avatar.id))
 
-      // where name is matching exactly so far (case insensitive)
-      if (startsWith(normA, text)) return -1
-      if (startsWith(normB, text)) return +1
-    })
+  const partialExactMatches = matches
+    .filter(m => !seenIds.has(m.avatar.id))
+    .filter(m => startsWith(m.name, text, false))
+    .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
+  partialExactMatches.forEach(m => seenIds.add(m.avatar.id))
 
-    .filter((el, i, arr) => {
-      if (i === 0) {
-        console.log('////////////////////////////////////////')
-        console.log(1)
-        console.log(arr.map(m => (m.avatar.id + m.name)))
-      }
-      return true
-    })
+  const partialNormalisedMatches = matches
+    .filter(m => !seenIds.has(m.avatar.id))
+    .filter(m => startsWith(normalise(m.name), normText, false))
+    .sort((a, b) => compareBool(isPreferredName(a), isPreferredName(b)))
+  partialNormalisedMatches.forEach(m => seenIds.add(m.avatar.id))
 
-    // bubble up names where typed word matches our name for them
-    .sort((a, b) => {
-      if (a.avatar.id !== b.avatar.id) return 0
+  const dreggs = matches.filter(m => !seenIds.has(m.avatar.id))
 
-      return compareBool(isPreferredName(a), isPreferredName(b))
-    })
+  const prioritisedMatches = [
+    ...exactMatches,
+    ...partialPreferredNameMatch,
+    ...exactNormalisedMatches,
+    ...partialExactMatches,
+    ...partialNormalisedMatches,
+    ...dreggs
+  ]
 
-    .filter((el, i, arr) => {
-      if (i === 0) {
-        console.log(2)
-        console.log(arr.map(m => (m.avatar.id + m.name)))
-      }
-      return true
-    })
+  seenIds = new Set() // reset for another use!
+
+  return prioritisedMatches
 
     // drop any duplicates of particular identities
     .reduce((soFar, match) => {

--- a/lib/reduce-matches.js
+++ b/lib/reduce-matches.js
@@ -1,0 +1,90 @@
+const normalise = require('./normalise')
+const startsWith = require('./starts-with')
+
+module.exports = function sort (text, matches) {
+  const normText = normalise(text)
+  var seenIds = new Set()
+
+  return matches
+    // for each person, bubble up the option where the match.name is the best match to search
+    .sort((a, b) => {
+      // if text+name are exact match
+      if (a.name === text) return -1
+      if (b.name === text) return +1
+
+      const normA = normalise(a.name)
+      const normB = normalise(b.name)
+
+      // where normalised text+name are exact match
+      if (normA === normText) return -1
+      if (normB === normText) return +1
+
+      // where name is matching exactly so far
+      if (startsWith(a.name, text, false)) return -1
+      if (startsWith(b.name, text, false)) return +1
+
+      // where name is matching exactly so far (case insensitive)
+      if (startsWith(normA, text)) return -1
+      if (startsWith(normB, text)) return +1
+    })
+
+    .filter((el, i, arr) => {
+      if (i === 0) {
+        console.log('////////////////////////////////////////')
+        console.log(1)
+        console.log(arr.map(m => (m.avatar.id + m.name)))
+      }
+      return true
+    })
+
+    // bubble up names where typed word matches our name for them
+    .sort((a, b) => {
+      if (a.avatar.id !== b.avatar.id) return 0
+
+      return compareBool(isPreferredName(a), isPreferredName(b))
+    })
+
+    .filter((el, i, arr) => {
+      if (i === 0) {
+        console.log(2)
+        console.log(arr.map(m => (m.avatar.id + m.name)))
+      }
+      return true
+    })
+
+    // drop any duplicates of particular identities
+    .reduce((soFar, match) => {
+      if (seenIds.has(match.avatar.id)) return soFar
+
+      seenIds.add(match.avatar.id)
+
+      const aliases = Array.isArray(match.avatar.names) ? new Set(match.avatar.names) : new Set()
+      aliases.delete(match.name)
+      match.avatar.aliases = Array.from(aliases)
+
+      soFar.push(match)
+      return soFar
+    }, [])
+
+    // push tombstones accounts to the bottom
+    // TODO replace once we have tombstones
+    .sort((a, b) => compareBool(!isDead(a), !isDead(b)))
+}
+
+function compareBool (a, b) {
+  if (a === b) return 0
+  if (a) return -1
+  if (b) return +1
+  return 0
+}
+
+function isPreferredName (match) {
+  return match.name === match.avatar.name
+}
+
+function isDead (match) {
+  return match.avatar.name.startsWith('deprecated') ||
+    match.avatar.name.startsWith('dead') ||
+    match.avatar.names.find(name => name.startsWith('deprecated')) ||
+    match.avatar.names.find(name => name.startsWith('dead'))
+}

--- a/lib/starts-with.js
+++ b/lib/starts-with.js
@@ -1,10 +1,15 @@
-var collator = typeof Intl === 'object' ?
-  new Intl.Collator('default', { sensitivity: 'base', usage: 'search' }) :
-  null
+var flat = require('./normalise')
+var collator = typeof Intl === 'object'
+  ? new Intl.Collator('default', { sensitivity: 'base', usage: 'search' })
+  : null
 
-module.exports = function startsWith (rawText, rawTarget) {
-  const text = rawText.toLocaleLowerCase()
-  const target = rawTarget.toLocaleLowerCase()
+module.exports = function startsWith (rawText, rawTarget, normalise = true) {
+  // some avatar.name are comming through as null
+  if (!rawText || !rawTarget) return false
+
+  const text = normalise ? flat(rawText) : rawText
+  const target = normalise ? flat(rawTarget) : rawTarget
+
   if (collator) return collator.compare(text.slice(0, target.length), target) === 0
   else if (text.slice(0, target.length).localeCompare(target) === 0) return true
   else return text.startsWith(target)


### PR DESCRIPTION
Some time ago I swapped `patch-about` to use this module, and in doing so dropped a nice algorithm which made really good at-mention recommendations.

![image](https://user-images.githubusercontent.com/2665886/74601621-0479d100-5105-11ea-9a0c-d5caee432c26.png)

I've resurrected it here, with some tweaks. What it prioritises, in order:
1. exact matches
2. partial matches on a recommendation which is our preferred name for that person
3. exact normalised match
4. partial exact match
5. partial normalised match

where:
- exact = text + case recommendation perfectly
- partial = what's been written so far matches the start a recommendation
- normalised = toLocaleLowerCase + `(\s|-|_)` stripped